### PR TITLE
FF 58 Compatibility

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -324,11 +324,11 @@ to use the close, minimize, and resize buttons */
 
 .tab-stack {width: 100%}
 
-.tabbrowser-tabs .scrollbox-innerbox {
+#tabbrowser-tabs .scrollbox-innerbox {
     display: flex;
     flex-wrap: wrap}
 
-.tabbrowser-tabs .arrowscrollbox-scrollbox {
+#tabbrowser-tabs .arrowscrollbox-scrollbox {
     overflow: visible;
     display: block}
 
@@ -356,7 +356,7 @@ to use the close, minimize, and resize buttons */
 
 #titlebar:active #titlebar-content {margin-bottom:var(--tab-min-height) !important}
 
-.tabbrowser-tabs .scrollbutton-up,.tabbrowser-tabs .scrollbutton-down,#alltabs-button,.tabbrowser-tab:not([fadein])
+#tabbrowser-tabs .scrollbutton-up,#tabbrowser-tabs .scrollbutton-down,#alltabs-button,.tabbrowser-tab:not([fadein])
 {display: none}
 
 /* MULTI-ROW BOOKMARKS TOOLBAR */


### PR DESCRIPTION
.tabbrowser-tabs class was removed and is now an ID.
This gets converted automatically when updating, but it doesn't work anymore if you start to use it in FF 58.